### PR TITLE
[docs] topic/fix how to test in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,18 @@ public fun save_latest_value(aggregator_addr: address) {
     });
 }
 
+#[test_only]
+use aptos_framework::account;
+#[test_only]
+use aptos_framework::block;
+#[test_only]
+use aptos_framework::timestamp;
 // some testing that uses aggregator test utility functions
-#[test(account = @0x1)]
-public entry fun test_aggregator(account: &signer) {
+#[test(aptos_framework = @0x1, account = @0x123)]
+public entry fun test_aggregator(aptos_framework: &signer, account: &signer) {
+    account::create_account_for_test(signer::address_of(aptos_framework));
+    block::initialize_for_test(aptos_framework, 1);
+    timestamp::set_time_has_started_for_testing(aptos_framework);
 
     // creates test aggregator with data
     aggregator::new_test(account, 100, 0, false);


### PR DESCRIPTION
# Description

fix description in README about test.

`aggregator::new_test` has dependencies with followings.
- `aptos_framework::timestamp`
- `aptos_framework::block`
     - `block::initialize_for_test` is called by @0x1 (aptos) with account, so need `account::create_account_for_test`