### PR TITLE
Remove unused aptos_framework::account use.

### DIFF
--- a/move/switchboard/sources/schemas/aggregator.move
+++ b/move/switchboard/sources/schemas/aggregator.move
@@ -1,5 +1,5 @@
 module switchboard::aggregator {
-    use aptos_framework::account::{Self, SignerCapability};
+    use aptos_framework::account::{SignerCapability};
     use aptos_framework::timestamp;
     use aptos_framework::block;
     use aptos_std::ed25519;
@@ -561,6 +561,9 @@ module switchboard::aggregator {
             latest_confirmed_round.round_confirmed_timestamp = timestamp::now_seconds();
         }
     }
+
+    #[test_only]
+    use aptos_framework::account;
 
     #[test_only]
     public entry fun new_test(account: &signer, value: u128, dec: u8, neg: bool) {


### PR DESCRIPTION
Remove aptos_framwork::acount::{Self} and move to [test_only]. 
Avoid for W09001 unused alias warning.